### PR TITLE
Panic freedom

### DIFF
--- a/.github/workflows/tls_codec.yml
+++ b/.github/workflows/tls_codec.yml
@@ -89,5 +89,5 @@ jobs:
           hax_reference: tls-codec-panic-freedom
       - name: 🏃 Extract F*
         run: cargo hax into fstar
-      - name: 🏃 Lax-check extracted F*
+      - name: 🏃 Type-check extracted F*
         run: make -C proofs/fstar/extraction/

--- a/.github/workflows/tls_codec.yml
+++ b/.github/workflows/tls_codec.yml
@@ -86,7 +86,8 @@ jobs:
         uses: hacspec/hax-actions@main
         with:
           fstar: v2025.08.07
+          hax_reference: tls-codec-panic-freedom
       - name: 🏃 Extract F*
         run: cargo hax into fstar
       - name: 🏃 Lax-check extracted F*
-        run: OTHERFLAGS="--admit_smt_queries true" make -C proofs/fstar/extraction/
+        run: make -C proofs/fstar/extraction/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1974,7 +1974,7 @@ version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f33196643e165781c20a5ead5582283a7dacbb87855d867fbc2df3f81eddc1be"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.4",
  "js-sys",
  "wasm-bindgen",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -764,6 +764,7 @@ checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 [[package]]
 name = "hax-lib"
 version = "0.3.4"
+source = "git+https://github.com/cryspen/hax?branch=tls-codec-panic-freedom#dece8bb8e811c747639f7c7595978fb00b726fa9"
 dependencies = [
  "hax-lib-macros",
  "num-bigint",
@@ -773,6 +774,7 @@ dependencies = [
 [[package]]
 name = "hax-lib-macros"
 version = "0.3.4"
+source = "git+https://github.com/cryspen/hax?branch=tls-codec-panic-freedom#dece8bb8e811c747639f7c7595978fb00b726fa9"
 dependencies = [
  "hax-lib-macros-types",
  "proc-macro-error2",
@@ -784,6 +786,7 @@ dependencies = [
 [[package]]
 name = "hax-lib-macros-types"
 version = "0.3.4"
+source = "git+https://github.com/cryspen/hax?branch=tls-codec-panic-freedom#dece8bb8e811c747639f7c7595978fb00b726fa9"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -763,8 +763,9 @@ checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "hax-lib"
-version = "0.3.5"
-source = "git+https://github.com/cryspen/hax?branch=tls-codec-panic-freedom#445f3a0ba8863b43287d10c0e8ed30052d3db747"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "543f93241d32b3f00569201bfce9d7a93c92c6421b23c77864ac929dc947b9fc"
 dependencies = [
  "hax-lib-macros",
  "num-bigint",
@@ -773,8 +774,9 @@ dependencies = [
 
 [[package]]
 name = "hax-lib-macros"
-version = "0.3.5"
-source = "git+https://github.com/cryspen/hax?branch=tls-codec-panic-freedom#445f3a0ba8863b43287d10c0e8ed30052d3db747"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8755751e760b11021765bb04cb4a6c4e24742688d9f3aa14c2079638f537b0f"
 dependencies = [
  "hax-lib-macros-types",
  "proc-macro-error2",
@@ -785,8 +787,9 @@ dependencies = [
 
 [[package]]
 name = "hax-lib-macros-types"
-version = "0.3.5"
-source = "git+https://github.com/cryspen/hax?branch=tls-codec-panic-freedom#445f3a0ba8863b43287d10c0e8ed30052d3db747"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f177c9ae8ea456e2f71ff3c1ea47bf4464f772a05133fcbba56cd5ba169035a2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -763,8 +763,8 @@ checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "hax-lib"
-version = "0.3.4"
-source = "git+https://github.com/cryspen/hax?branch=tls-codec-panic-freedom#a06153e29dd8eaab49ccda66a6b9e482980360e0"
+version = "0.3.5"
+source = "git+https://github.com/cryspen/hax?branch=tls-codec-panic-freedom#445f3a0ba8863b43287d10c0e8ed30052d3db747"
 dependencies = [
  "hax-lib-macros",
  "num-bigint",
@@ -773,8 +773,8 @@ dependencies = [
 
 [[package]]
 name = "hax-lib-macros"
-version = "0.3.4"
-source = "git+https://github.com/cryspen/hax?branch=tls-codec-panic-freedom#a06153e29dd8eaab49ccda66a6b9e482980360e0"
+version = "0.3.5"
+source = "git+https://github.com/cryspen/hax?branch=tls-codec-panic-freedom#445f3a0ba8863b43287d10c0e8ed30052d3db747"
 dependencies = [
  "hax-lib-macros-types",
  "proc-macro-error2",
@@ -785,8 +785,8 @@ dependencies = [
 
 [[package]]
 name = "hax-lib-macros-types"
-version = "0.3.4"
-source = "git+https://github.com/cryspen/hax?branch=tls-codec-panic-freedom#a06153e29dd8eaab49ccda66a6b9e482980360e0"
+version = "0.3.5"
+source = "git+https://github.com/cryspen/hax?branch=tls-codec-panic-freedom#445f3a0ba8863b43287d10c0e8ed30052d3db747"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -763,8 +763,7 @@ checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "hax-lib"
-version = "0.3.1"
-source = "git+https://github.com/cryspen/hax?branch=tls-codec-lib#89146496aa29fff2137635020f58a03a1ffb7caa"
+version = "0.3.4"
 dependencies = [
  "hax-lib-macros",
  "num-bigint",
@@ -773,8 +772,7 @@ dependencies = [
 
 [[package]]
 name = "hax-lib-macros"
-version = "0.3.1"
-source = "git+https://github.com/cryspen/hax?branch=tls-codec-lib#89146496aa29fff2137635020f58a03a1ffb7caa"
+version = "0.3.4"
 dependencies = [
  "hax-lib-macros-types",
  "proc-macro-error2",
@@ -785,8 +783,7 @@ dependencies = [
 
 [[package]]
 name = "hax-lib-macros-types"
-version = "0.3.1"
-source = "git+https://github.com/cryspen/hax?branch=tls-codec-lib#89146496aa29fff2137635020f58a03a1ffb7caa"
+version = "0.3.4"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -764,7 +764,7 @@ checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 [[package]]
 name = "hax-lib"
 version = "0.3.4"
-source = "git+https://github.com/cryspen/hax?branch=tls-codec-panic-freedom#dece8bb8e811c747639f7c7595978fb00b726fa9"
+source = "git+https://github.com/cryspen/hax?branch=tls-codec-panic-freedom#a06153e29dd8eaab49ccda66a6b9e482980360e0"
 dependencies = [
  "hax-lib-macros",
  "num-bigint",
@@ -774,7 +774,7 @@ dependencies = [
 [[package]]
 name = "hax-lib-macros"
 version = "0.3.4"
-source = "git+https://github.com/cryspen/hax?branch=tls-codec-panic-freedom#dece8bb8e811c747639f7c7595978fb00b726fa9"
+source = "git+https://github.com/cryspen/hax?branch=tls-codec-panic-freedom#a06153e29dd8eaab49ccda66a6b9e482980360e0"
 dependencies = [
  "hax-lib-macros-types",
  "proc-macro-error2",
@@ -786,7 +786,7 @@ dependencies = [
 [[package]]
 name = "hax-lib-macros-types"
 version = "0.3.4"
-source = "git+https://github.com/cryspen/hax?branch=tls-codec-panic-freedom#dece8bb8e811c747639f7c7595978fb00b726fa9"
+source = "git+https://github.com/cryspen/hax?branch=tls-codec-panic-freedom#a06153e29dd8eaab49ccda66a6b9e482980360e0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/tls_codec/Cargo.toml
+++ b/tls_codec/Cargo.toml
@@ -16,7 +16,7 @@ zeroize = { version = "1.8", default-features = false, features = [
     "alloc",
     "zeroize_derive",
 ] }
-hax-lib = {git = "https://github.com/cryspen/hax", branch = "tls-codec-panic-freedom"}
+hax-lib = "0.3.6"
 
 # optional dependencies
 arbitrary = { version = "1.4", features = ["derive"], optional = true }

--- a/tls_codec/Cargo.toml
+++ b/tls_codec/Cargo.toml
@@ -16,7 +16,7 @@ zeroize = { version = "1.8", default-features = false, features = [
     "alloc",
     "zeroize_derive",
 ] }
-hax-lib = {path = "../../hax/hax-lib"}
+hax-lib = {git = "https://github.com/cryspen/hax", branch = "tls-codec-panic-freedom"}
 
 # optional dependencies
 arbitrary = { version = "1.4", features = ["derive"], optional = true }

--- a/tls_codec/Cargo.toml
+++ b/tls_codec/Cargo.toml
@@ -16,7 +16,7 @@ zeroize = { version = "1.8", default-features = false, features = [
     "alloc",
     "zeroize_derive",
 ] }
-hax-lib = {git = "https://github.com/cryspen/hax", branch = "tls-codec-lib"}
+hax-lib = {path = "../../hax/hax-lib"}
 
 # optional dependencies
 arbitrary = { version = "1.4", features = ["derive"], optional = true }

--- a/tls_codec/derive/src/lib.rs
+++ b/tls_codec/derive/src/lib.rs
@@ -90,6 +90,10 @@
 //!         TlsByteSliceU32(v).tls_serialized_len()
 //!     }
 //!
+//!     pub fn tls_serialized_len_checked(v: &[u8]) -> Option<usize> {
+//!         TlsByteSliceU32(v).tls_serialized_len_checked()
+//!     }
+//!
 //!     pub fn tls_serialize<W: Write>(v: &[u8], writer: &mut W) -> Result<usize, tls_codec::Error> {
 //!         TlsByteSliceU32(v).tls_serialize(writer)
 //!     }
@@ -787,12 +791,20 @@ fn impl_tls_size(parsed_ast: TlsStruct) -> TokenStream2 {
                         #(#prefixes::tls_serialized_len(&self.#members) + )*
                         0
                     }
+                    #[inline]
+                    fn tls_serialized_len_checked(&self) -> Option<usize> {
+                        Some(0usize#(.checked_add(#prefixes::tls_serialized_len_checked(&self.#members)?)?)*)
+                    }
                 }
 
                 impl #impl_generics tls_codec::Size for &#ident #ty_generics #where_clause {
                     #[inline]
                     fn tls_serialized_len(&self) -> usize {
                         tls_codec::Size::tls_serialized_len(*self)
+                    }
+                    #[inline]
+                    fn tls_serialized_len_checked(&self) -> Option<usize> {
+                        tls_codec::Size::tls_serialized_len_checked(*self)
                     }
                 }
             }
@@ -827,12 +839,23 @@ fn impl_tls_size(parsed_ast: TlsStruct) -> TokenStream2 {
                         };
                         core::mem::size_of::<#repr>() + field_len
                     }
+                    #[inline]
+                    fn tls_serialized_len_checked(&self) -> Option<usize> {
+                        let field_len = match self {
+                            #(#field_arms)*
+                        };
+                        core::mem::size_of::<#repr>().checked_add(field_len)
+                    }
                 }
 
                 impl #impl_generics tls_codec::Size for &#ident #ty_generics #where_clause {
                     #[inline]
                     fn tls_serialized_len(&self) -> usize {
                         tls_codec::Size::tls_serialized_len(*self)
+                    }
+                    #[inline]
+                    fn tls_serialized_len_checked(&self) -> Option<usize> {
+                        tls_codec::Size::tls_serialized_len_checked(*self)
                     }
                 }
             }

--- a/tls_codec/derive/src/lib.rs
+++ b/tls_codec/derive/src/lib.rs
@@ -792,6 +792,7 @@ fn impl_tls_size(parsed_ast: TlsStruct) -> TokenStream2 {
                         0
                     }
                     #[inline]
+                    #[allow(clippy::needless_question_mark)]
                     fn tls_serialized_len_checked(&self) -> Option<usize> {
                         Some(0usize#(.checked_add(#prefixes::tls_serialized_len_checked(&self.#members)?)?)*)
                     }

--- a/tls_codec/derive/tests/decode.rs
+++ b/tls_codec/derive/tests/decode.rs
@@ -269,6 +269,10 @@ mod custom {
         TlsByteSliceU32(v).tls_serialized_len()
     }
 
+    pub fn tls_serialized_len_checked(v: &[u8]) -> Option<usize> {
+        TlsByteSliceU32(v).tls_serialized_len_checked()
+    }
+
     pub fn tls_serialize<W: Write>(v: &[u8], writer: &mut W) -> Result<usize, tls_codec::Error> {
         TlsByteSliceU32(v).tls_serialize(writer)
     }
@@ -291,6 +295,10 @@ mod custom_bytes {
 
     pub fn tls_serialized_len(v: &[u8]) -> usize {
         TlsByteSliceU32(v).tls_serialized_len()
+    }
+
+    pub fn tls_serialized_len_checked(v: &[u8]) -> Option<usize> {
+        TlsByteSliceU32(v).tls_serialized_len_checked()
     }
 
     pub fn tls_serialize<W: Write>(v: &[u8], writer: &mut W) -> Result<usize, tls_codec::Error> {

--- a/tls_codec/derive/tests/decode_bytes.rs
+++ b/tls_codec/derive/tests/decode_bytes.rs
@@ -90,6 +90,10 @@ mod custom {
         v.tls_serialized_len()
     }
 
+    pub fn tls_serialized_len_checked(v: &[u8]) -> Option<usize> {
+        v.tls_serialized_len_checked()
+    }
+
     pub fn tls_serialize(v: &[u8]) -> Result<Vec<u8>, tls_codec::Error> {
         v.tls_serialize()
     }

--- a/tls_codec/derive/tests/encode.rs
+++ b/tls_codec/derive/tests/encode.rs
@@ -131,6 +131,10 @@ mod custom {
         TlsByteSliceU32(v).tls_serialized_len()
     }
 
+    pub fn tls_serialized_len_checked(v: &[u8]) -> Option<usize> {
+        TlsByteSliceU32(v).tls_serialized_len_checked()
+    }
+
     pub fn tls_serialize<W: Write>(v: &[u8], writer: &mut W) -> Result<usize, tls_codec::Error> {
         TlsByteSliceU32(v).tls_serialize(writer)
     }

--- a/tls_codec/derive/tests/encode_bytes.rs
+++ b/tls_codec/derive/tests/encode_bytes.rs
@@ -107,6 +107,10 @@ mod custom {
         v.tls_serialized_len()
     }
 
+    pub fn tls_serialized_len_checked(v: &[u8]) -> Option<usize> {
+        v.tls_serialized_len_checked()
+    }
+
     pub fn tls_serialize(v: &[u8]) -> Result<Vec<u8>, tls_codec::Error> {
         v.tls_serialize()
     }

--- a/tls_codec/proofs/fstar/models/Zeroize.fsti
+++ b/tls_codec/proofs/fstar/models/Zeroize.fsti
@@ -1,6 +1,6 @@
 module Zeroize
 #set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
-open Core
+open Core_models
 open FStar.Mul
 
 class t_Zeroize (v_Self: Type0) = {

--- a/tls_codec/src/arrays.rs
+++ b/tls_codec/src/arrays.rs
@@ -51,4 +51,8 @@ impl<const LEN: usize> Size for [u8; LEN] {
     fn tls_serialized_len(&self) -> usize {
         LEN
     }
+    #[inline]
+    fn tls_serialized_len_checked(&self) -> Option<usize> {
+        Some(LEN)
+    }
 }

--- a/tls_codec/src/arrays.rs
+++ b/tls_codec/src/arrays.rs
@@ -35,12 +35,8 @@ impl<const LEN: usize> Deserialize for [u8; LEN] {
 impl<const LEN: usize> DeserializeBytes for [u8; LEN] {
     #[inline]
     fn tls_deserialize_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
-        let out = bytes
-            .get(..LEN)
-            .ok_or(Error::EndOfStream)?
-            .try_into()
-            .map_err(|_| Error::EndOfStream)?;
-        Ok((out, &bytes[LEN..]))
+        let (out, remainder) = bytes.split_at_checked(LEN).ok_or(Error::EndOfStream)?;
+        Ok((out.try_into().map_err(|_| Error::EndOfStream)?, remainder))
     }
 }
 

--- a/tls_codec/src/lib.rs
+++ b/tls_codec/src/lib.rs
@@ -110,6 +110,8 @@ mod serialize_bytes {
     #[hax_lib::attributes]
     pub trait Size {
         #[hax_lib::requires(true)]
+        fn tls_serialized_len_checked(&self) -> Option<usize>;
+        #[hax_lib::requires(true)]
         fn tls_serialized_len(&self) -> usize;
     }
 

--- a/tls_codec/src/lib.rs
+++ b/tls_codec/src/lib.rs
@@ -287,7 +287,6 @@ impl U24 {
     }
 }
 
-#[hax_lib::fstar::options("--z3rlimit 00")]
 impl From<U24> for usize {
     fn from(value: U24) -> usize {
         const LEN: usize = core::mem::size_of::<usize>();
@@ -308,7 +307,7 @@ impl TryFrom<usize> for U24 {
         if value > (1 << 24) - 1 {
             Err(Error::LibraryError)
         } else {
-            hax_lib::assume!(LEN == 8);  // https://github.com/cryspen/hax/issues/1702
+            hax_lib::assume!(LEN == 8); // https://github.com/cryspen/hax/issues/1702
             Ok(U24(value.to_be_bytes()[LEN - 3..].try_into()?))
         }
     }

--- a/tls_codec/src/lib.rs
+++ b/tls_codec/src/lib.rs
@@ -107,7 +107,9 @@ mod serialize_bytes {
     /// efficiently serialized.
     /// This allows to collect the length of a serialized structure before allocating
     /// memory.
+    #[hax_lib::attributes]
     pub trait Size {
+        #[hax_lib::requires(true)]
         fn tls_serialized_len(&self) -> usize;
     }
 
@@ -115,8 +117,10 @@ mod serialize_bytes {
     ///
     /// The trait provides one function:
     /// * `tls_serialize` that returns a byte vector
+    #[hax_lib::attributes]
     pub trait SerializeBytes: Size {
         /// Serialize `self` and return it as a byte vector.
+        #[hax_lib::requires(true)]
         fn tls_serialize(&self) -> Result<Vec<u8>, Error>;
     }
 }
@@ -146,10 +150,12 @@ impl From<std::io::Error> for Error {
 /// The trait provides two functions:
 /// * `tls_serialize` that takes a buffer to write the serialization to
 /// * `tls_serialize_detached` that returns a byte vector
+#[hax_lib::attributes]
 pub trait Serialize: Size {
     /// Serialize `self` and write it to the `writer`.
     /// The function returns the number of bytes written to `writer`.
     #[cfg(feature = "std")]
+    #[hax_lib::requires(true)]
     fn tls_serialize<W: Write>(&self, writer: &mut W) -> Result<usize, Error>;
 
     /// Serialize `self` and return it as a byte vector.
@@ -164,6 +170,7 @@ pub trait Serialize: Size {
 fn tls_serialize_detached_default<T: ?Sized + Serialize>(s: &T) -> Result<Vec<u8>, Error> {
     let mut buffer = Vec::with_capacity(s.tls_serialized_len());
     let written = s.tls_serialize(&mut buffer)?;
+    #[cfg(not(hax))]
     debug_assert_eq!(
         written,
         buffer.len(),
@@ -184,6 +191,7 @@ fn tls_serialize_detached_default<T: ?Sized + Serialize>(s: &T) -> Result<Vec<u8
 
 /// The `Deserialize` trait defines functions to deserialize a byte slice to a
 /// struct or enum.
+#[hax_lib::attributes]
 pub trait Deserialize: Size {
     /// This function deserializes the `bytes` from the provided a [`std::io::Read`]
     /// and returns the populated struct.
@@ -192,6 +200,7 @@ pub trait Deserialize: Size {
     ///
     /// Returns an error if one occurs during deserialization.
     #[cfg(feature = "std")]
+    #[hax_lib::requires(true)]
     fn tls_deserialize<R: Read>(bytes: &mut R) -> Result<Self, Error>
     where
         Self: Sized;
@@ -226,6 +235,7 @@ fn tls_deserialize_exact_default<T: Deserialize>(bytes: impl AsRef<[u8]>) -> Res
 /// The `DeserializeBytes` trait defines functions to deserialize a byte slice
 /// to a struct or enum. In contrast to [`Deserialize`], this trait operates
 /// directly on byte slices and can return any remaining bytes.
+#[hax_lib::attributes]
 pub trait DeserializeBytes: Size {
     /// This function deserializes the `bytes` from the provided a `&[u8]`
     /// and returns the populated struct, as well as the remaining slice.
@@ -233,6 +243,7 @@ pub trait DeserializeBytes: Size {
     /// In order to get the amount of bytes read, use [`Size::tls_serialized_len`].
     ///
     /// Returns an error if one occurs during deserialization.
+    #[hax_lib::requires(true)]
     fn tls_deserialize_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), Error>
     where
         Self: Sized;
@@ -276,10 +287,12 @@ impl U24 {
     }
 }
 
+#[hax_lib::fstar::options("--z3rlimit 00")]
 impl From<U24> for usize {
     fn from(value: U24) -> usize {
         const LEN: usize = core::mem::size_of::<usize>();
         let mut usize_bytes = [0u8; LEN];
+        hax_lib::assume!(LEN == 8); // https://github.com/cryspen/hax/issues/1702
         usize_bytes[LEN - 3..].copy_from_slice(&value.0);
         usize::from_be_bytes(usize_bytes)
     }
@@ -288,13 +301,14 @@ impl From<U24> for usize {
 impl TryFrom<usize> for U24 {
     type Error = Error;
 
-    fn try_from(value: usize) -> Result<Self, Self::Error> {
+    fn try_from(value: usize) -> Result<Self, Error> {
         const LEN: usize = core::mem::size_of::<usize>();
         // In practice, our usages of this conversion should never be invalid, as the values
         // have to come from `TryFrom<U24> for usize`.
         if value > (1 << 24) - 1 {
             Err(Error::LibraryError)
         } else {
+            hax_lib::assume!(LEN == 8);  // https://github.com/cryspen/hax/issues/1702
             Ok(U24(value.to_be_bytes()[LEN - 3..].try_into()?))
         }
     }

--- a/tls_codec/src/lib.rs
+++ b/tls_codec/src/lib.rs
@@ -291,7 +291,7 @@ impl From<U24> for usize {
     fn from(value: U24) -> usize {
         const LEN: usize = core::mem::size_of::<usize>();
         let mut usize_bytes = [0u8; LEN];
-        hax_lib::assume!(LEN == 8); // https://github.com/cryspen/hax/issues/1702
+        hax_lib::assume!(usize_bytes.len() == LEN); // https://github.com/cryspen/hax/issues/1702
         usize_bytes[LEN - 3..].copy_from_slice(&value.0);
         usize::from_be_bytes(usize_bytes)
     }
@@ -307,7 +307,7 @@ impl TryFrom<usize> for U24 {
         if value > (1 << 24) - 1 {
             Err(Error::LibraryError)
         } else {
-            hax_lib::assume!(LEN == 8); // https://github.com/cryspen/hax/issues/1702
+            hax_lib::assume!(value.to_be_bytes().len() == LEN); // https://github.com/cryspen/hax/issues/1702
             Ok(U24(value.to_be_bytes()[LEN - 3..].try_into()?))
         }
     }

--- a/tls_codec/src/primitives.rs
+++ b/tls_codec/src/primitives.rs
@@ -20,12 +20,10 @@ impl<T: Size> Size for Option<T> {
     }
     #[inline]
     fn tls_serialized_len(&self) -> usize {
-        1usize
-            .checked_add(match self {
-                Some(v) => v.tls_serialized_len(),
-                None => 0,
-            })
-            .unwrap_or(0)
+        1 + match self {
+            Some(v) => v.tls_serialized_len(),
+            None => 0,
+        }
     }
 }
 
@@ -285,10 +283,7 @@ where
     }
     #[inline(always)]
     fn tls_serialized_len(&self) -> usize {
-        self.0
-            .tls_serialized_len()
-            .checked_add(self.1.tls_serialized_len())
-            .unwrap_or(0)
+        self.0.tls_serialized_len() + self.1.tls_serialized_len()
     }
 }
 
@@ -359,12 +354,7 @@ where
     }
     #[inline(always)]
     fn tls_serialized_len(&self) -> usize {
-        self.0
-            .tls_serialized_len()
-            .checked_add(self.1.tls_serialized_len())
-            .unwrap_or(0)
-            .checked_add(self.2.tls_serialized_len())
-            .unwrap_or(0)
+        self.0.tls_serialized_len() + self.1.tls_serialized_len() + self.2.tls_serialized_len()
     }
 }
 

--- a/tls_codec/src/primitives.rs
+++ b/tls_codec/src/primitives.rs
@@ -37,7 +37,7 @@ impl<T: Serialize> Serialize for Option<T> {
                 #[cfg(not(hax))]
                 debug_assert_eq!(written, 1);
                 e.tls_serialize(writer).map(|l| {
-                    hax_lib::assume!(l <= 1000);
+                    hax_lib::fstar!("admit ()"); // overflow
                     l + 1
                 })
             }
@@ -54,7 +54,7 @@ impl<T: SerializeBytes> SerializeBytes for Option<T> {
     fn tls_serialize(&self) -> Result<Vec<u8>, Error> {
         match self {
             Some(e) => {
-                hax_lib::assume!(e.tls_serialized_len() <= 1000);
+                hax_lib::fstar!("admit ()"); // overflow
                 let mut out = Vec::with_capacity(e.tls_serialized_len() + 1);
                 out.push(1);
                 // Not inlining serialized_e is a workaround for
@@ -244,7 +244,7 @@ where
     fn tls_serialize<W: Write>(&self, writer: &mut W) -> Result<usize, Error> {
         let written = self.0.tls_serialize(writer)?;
         self.1.tls_serialize(writer).map(|l| {
-            hax_lib::assume!(l < 1000 && written < 1000);
+            hax_lib::fstar!("admit ()"); // overflow
             l + written
         })
     }
@@ -257,7 +257,7 @@ where
 {
     #[inline(always)]
     fn tls_serialized_len(&self) -> usize {
-        hax_lib::assume!(self.0.tls_serialized_len() < 1000 && self.1.tls_serialized_len() < 1000);
+        hax_lib::fstar!("admit ()"); // overflow
         self.0.tls_serialized_len() + self.1.tls_serialized_len()
     }
 }
@@ -306,10 +306,7 @@ where
         let mut written = self.0.tls_serialize(writer)?;
         hax_lib::fstar!("admit ()"); // overflow
         written += self.1.tls_serialize(writer)?;
-        self.2.tls_serialize(writer).map(|l| {
-            hax_lib::assume!(l < 1000 && written < 1000);
-            l + written
-        })
+        self.2.tls_serialize(writer).map(|l| l + written)
     }
 }
 
@@ -321,11 +318,7 @@ where
 {
     #[inline(always)]
     fn tls_serialized_len(&self) -> usize {
-        hax_lib::assume!(
-            self.0.tls_serialized_len() < 1000
-                && self.1.tls_serialized_len() < 1000
-                && self.2.tls_serialized_len() < 1000
-        );
+        hax_lib::fstar!("admit ()"); // overflow
         self.0.tls_serialized_len() + self.1.tls_serialized_len() + self.2.tls_serialized_len()
     }
 }

--- a/tls_codec/src/primitives.rs
+++ b/tls_codec/src/primitives.rs
@@ -13,6 +13,7 @@ use std::io::{Read, Write};
 impl<T: Size> Size for Option<T> {
     #[inline]
     fn tls_serialized_len(&self) -> usize {
+        hax_lib::fstar!("admit ()"); // overflow
         1 + match self {
             Some(v) => v.tls_serialized_len(),
             None => 0,
@@ -33,8 +34,12 @@ impl<T: Serialize> Serialize for Option<T> {
         match self {
             Some(e) => {
                 let written = writer.write(&[1])?;
+                #[cfg(not(hax))]
                 debug_assert_eq!(written, 1);
-                e.tls_serialize(writer).map(|l| l + 1)
+                e.tls_serialize(writer).map(|l| {
+                    hax_lib::assume!(l <= 1000);
+                    l + 1
+                })
             }
             None => {
                 writer.write_all(&[0])?;
@@ -49,6 +54,7 @@ impl<T: SerializeBytes> SerializeBytes for Option<T> {
     fn tls_serialize(&self) -> Result<Vec<u8>, Error> {
         match self {
             Some(e) => {
+                hax_lib::assume!(e.tls_serialized_len() <= 1000);
                 let mut out = Vec::with_capacity(e.tls_serialized_len() + 1);
                 out.push(1);
                 // Not inlining serialized_e is a workaround for
@@ -160,6 +166,7 @@ macro_rules! impl_unsigned {
             #[inline]
             fn tls_serialize<W: Write>(&self, writer: &mut W) -> Result<usize, Error> {
                 let written = writer.write(&self.to_be_bytes())?;
+                #[cfg(not(hax))]
                 debug_assert_eq!(written, $bytes);
                 Ok(written)
             }
@@ -236,7 +243,10 @@ where
     #[inline(always)]
     fn tls_serialize<W: Write>(&self, writer: &mut W) -> Result<usize, Error> {
         let written = self.0.tls_serialize(writer)?;
-        self.1.tls_serialize(writer).map(|l| l + written)
+        self.1.tls_serialize(writer).map(|l| {
+            hax_lib::assume!(l < 1000 && written < 1000);
+            l + written
+        })
     }
 }
 
@@ -247,6 +257,7 @@ where
 {
     #[inline(always)]
     fn tls_serialized_len(&self) -> usize {
+        hax_lib::assume!(self.0.tls_serialized_len() < 1000 && self.1.tls_serialized_len() < 1000);
         self.0.tls_serialized_len() + self.1.tls_serialized_len()
     }
 }
@@ -293,8 +304,12 @@ where
     #[inline(always)]
     fn tls_serialize<W: Write>(&self, writer: &mut W) -> Result<usize, Error> {
         let mut written = self.0.tls_serialize(writer)?;
+        hax_lib::fstar!("admit ()"); // overflow
         written += self.1.tls_serialize(writer)?;
-        self.2.tls_serialize(writer).map(|l| l + written)
+        self.2.tls_serialize(writer).map(|l| {
+            hax_lib::assume!(l < 1000 && written < 1000);
+            l + written
+        })
     }
 }
 
@@ -306,6 +321,11 @@ where
 {
     #[inline(always)]
     fn tls_serialized_len(&self) -> usize {
+        hax_lib::assume!(
+            self.0.tls_serialized_len() < 1000
+                && self.1.tls_serialized_len() < 1000
+                && self.2.tls_serialized_len() < 1000
+        );
         self.0.tls_serialized_len() + self.1.tls_serialized_len() + self.2.tls_serialized_len()
     }
 }

--- a/tls_codec/src/primitives.rs
+++ b/tls_codec/src/primitives.rs
@@ -12,12 +12,20 @@ use std::io::{Read, Write};
 
 impl<T: Size> Size for Option<T> {
     #[inline]
-    fn tls_serialized_len(&self) -> usize {
-        hax_lib::fstar!("admit ()"); // overflow
-        1 + match self {
-            Some(v) => v.tls_serialized_len(),
+    fn tls_serialized_len_checked(&self) -> Option<usize> {
+        1usize.checked_add(match self {
+            Some(v) => v.tls_serialized_len_checked()?,
             None => 0,
-        }
+        })
+    }
+    #[inline]
+    fn tls_serialized_len(&self) -> usize {
+        1usize
+            .checked_add(match self {
+                Some(v) => v.tls_serialized_len(),
+                None => 0,
+            })
+            .unwrap_or(0)
     }
 }
 
@@ -25,6 +33,10 @@ impl<T: Size> Size for &Option<T> {
     #[inline]
     fn tls_serialized_len(&self) -> usize {
         (*self).tls_serialized_len()
+    }
+    #[inline]
+    fn tls_serialized_len_checked(&self) -> Option<usize> {
+        (*self).tls_serialized_len_checked()
     }
 }
 
@@ -187,12 +199,20 @@ macro_rules! impl_unsigned {
             fn tls_serialized_len(&self) -> usize {
                 $bytes
             }
+            #[inline]
+            fn tls_serialized_len_checked(&self) -> Option<usize> {
+                Some($bytes)
+            }
         }
 
         impl Size for &$t {
             #[inline]
             fn tls_serialized_len(&self) -> usize {
                 (*self).tls_serialized_len()
+            }
+            #[inline]
+            fn tls_serialized_len_checked(&self) -> Option<usize> {
+                (*self).tls_serialized_len_checked()
             }
         }
     };
@@ -258,9 +278,17 @@ where
     U: Size,
 {
     #[inline(always)]
+    fn tls_serialized_len_checked(&self) -> Option<usize> {
+        self.0
+            .tls_serialized_len_checked()?
+            .checked_add(self.1.tls_serialized_len_checked()?)
+    }
+    #[inline(always)]
     fn tls_serialized_len(&self) -> usize {
-        hax_lib::fstar!("admit ()"); // overflow
-        self.0.tls_serialized_len() + self.1.tls_serialized_len()
+        self.0
+            .tls_serialized_len()
+            .checked_add(self.1.tls_serialized_len())
+            .unwrap_or(0)
     }
 }
 
@@ -323,9 +351,20 @@ where
     V: Size,
 {
     #[inline(always)]
+    fn tls_serialized_len_checked(&self) -> Option<usize> {
+        self.0
+            .tls_serialized_len_checked()?
+            .checked_add(self.1.tls_serialized_len_checked()?)?
+            .checked_add(self.2.tls_serialized_len_checked()?)
+    }
+    #[inline(always)]
     fn tls_serialized_len(&self) -> usize {
-        hax_lib::fstar!("admit ()"); // overflow
-        self.0.tls_serialized_len() + self.1.tls_serialized_len() + self.2.tls_serialized_len()
+        self.0
+            .tls_serialized_len()
+            .checked_add(self.1.tls_serialized_len())
+            .unwrap_or(0)
+            .checked_add(self.2.tls_serialized_len())
+            .unwrap_or(0)
     }
 }
 
@@ -333,6 +372,10 @@ impl Size for () {
     #[inline(always)]
     fn tls_serialized_len(&self) -> usize {
         0
+    }
+    #[inline(always)]
+    fn tls_serialized_len_checked(&self) -> Option<usize> {
+        Some(0)
     }
 }
 
@@ -362,6 +405,10 @@ impl<T> Size for PhantomData<T> {
     #[inline(always)]
     fn tls_serialized_len(&self) -> usize {
         0
+    }
+    #[inline(always)]
+    fn tls_serialized_len_checked(&self) -> Option<usize> {
+        Some(0)
     }
 }
 
@@ -399,6 +446,10 @@ impl<T: Size> Size for Box<T> {
     #[inline(always)]
     fn tls_serialized_len(&self) -> usize {
         self.as_ref().tls_serialized_len()
+    }
+    #[inline(always)]
+    fn tls_serialized_len_checked(&self) -> Option<usize> {
+        self.as_ref().tls_serialized_len_checked()
     }
 }
 

--- a/tls_codec/src/primitives.rs
+++ b/tls_codec/src/primitives.rs
@@ -6,6 +6,9 @@ use crate::{DeserializeBytes, SerializeBytes, U24};
 
 use super::{Deserialize, Error, Serialize, Size};
 
+#[cfg(hax)]
+use hax_lib::ToInt;
+
 use core::marker::PhantomData;
 #[cfg(feature = "std")]
 use std::io::{Read, Write};
@@ -32,7 +35,10 @@ impl<T: Size> Size for Option<T> {
     #[inline]
     fn tls_serialized_len(&self) -> usize {
         1 + match self {
-            Some(v) => v.tls_serialized_len(),
+            Some(v) => {
+                hax_lib::assume!(v.tls_serialized_len() < usize::MAX);
+                v.tls_serialized_len()
+            }
             None => 0,
         }
     }
@@ -77,6 +83,8 @@ impl<T: SerializeBytes> SerializeBytes for Option<T> {
                 // Not inlining serialized_e is a workaround for
                 // https://github.com/cryspen/hax/issues/1584
                 let mut serialized_e = e.tls_serialize()?;
+                // Could be turned into a post-condition on `tls_serialize`
+                hax_lib::assume!(serialized_e.len() == e.tls_serialized_len());
                 out.append(&mut serialized_e);
                 Ok(out)
             }
@@ -285,6 +293,10 @@ where
     }
     #[inline(always)]
     fn tls_serialized_len(&self) -> usize {
+        hax_lib::assume!(
+            self.0.tls_serialized_len().to_int() + self.1.tls_serialized_len().to_int()
+                <= usize::MAX.to_int()
+        );
         self.0.tls_serialized_len() + self.1.tls_serialized_len()
     }
 }
@@ -351,6 +363,12 @@ where
     }
     #[inline(always)]
     fn tls_serialized_len(&self) -> usize {
+        hax_lib::assume!(
+            self.0.tls_serialized_len().to_int()
+                + self.1.tls_serialized_len().to_int()
+                + self.2.tls_serialized_len().to_int()
+                <= usize::MAX.to_int()
+        );
         self.0.tls_serialized_len() + self.1.tls_serialized_len() + self.2.tls_serialized_len()
     }
 }

--- a/tls_codec/src/primitives.rs
+++ b/tls_codec/src/primitives.rs
@@ -10,6 +10,17 @@ use core::marker::PhantomData;
 #[cfg(feature = "std")]
 use std::io::{Read, Write};
 
+macro_rules! add {
+    ($x: expr, $y: expr) => {
+        if cfg!(debug_assertions) {
+            $x.checked_add($y).ok_or(Error::LibraryError)?
+        } else {
+            $x + $y
+        }
+    };
+}
+pub(crate) use add;
+
 impl<T: Size> Size for Option<T> {
     #[inline]
     fn tls_serialized_len_checked(&self) -> Option<usize> {
@@ -46,9 +57,7 @@ impl<T: Serialize> Serialize for Option<T> {
                 let written = writer.write(&[1])?;
                 hax_lib::assume!(written == 1);
                 debug_assert_eq!(written, 1);
-                e.tls_serialize(writer)?
-                    .checked_add(1)
-                    .ok_or(Error::LibraryError)
+                Ok(add!(e.tls_serialize(writer)?, 1))
             }
             None => {
                 writer.write_all(&[0])?;
@@ -63,11 +72,7 @@ impl<T: SerializeBytes> SerializeBytes for Option<T> {
     fn tls_serialize(&self) -> Result<Vec<u8>, Error> {
         match self {
             Some(e) => {
-                let mut out = Vec::with_capacity(
-                    e.tls_serialized_len()
-                        .checked_add(1)
-                        .ok_or(Error::LibraryError)?,
-                );
+                let mut out = Vec::with_capacity(add!(e.tls_serialized_len(), 1));
                 out.push(1);
                 // Not inlining serialized_e is a workaround for
                 // https://github.com/cryspen/hax/issues/1584
@@ -263,10 +268,7 @@ where
     #[inline(always)]
     fn tls_serialize<W: Write>(&self, writer: &mut W) -> Result<usize, Error> {
         let written = self.0.tls_serialize(writer)?;
-        self.1
-            .tls_serialize(writer)?
-            .checked_add(written)
-            .ok_or(Error::LibraryError)
+        Ok(add!(self.1.tls_serialize(writer)?, written))
     }
 }
 
@@ -329,13 +331,8 @@ where
     #[inline(always)]
     fn tls_serialize<W: Write>(&self, writer: &mut W) -> Result<usize, Error> {
         let written = self.0.tls_serialize(writer)?;
-        let written = written
-            .checked_add(self.1.tls_serialize(writer)?)
-            .ok_or(Error::LibraryError)?;
-        self.2
-            .tls_serialize(writer)?
-            .checked_add(written)
-            .ok_or(Error::LibraryError)
+        let written = add!(written, self.1.tls_serialize(writer)?);
+        Ok(add!(self.2.tls_serialize(writer)?, written))
     }
 }
 

--- a/tls_codec/src/primitives.rs
+++ b/tls_codec/src/primitives.rs
@@ -34,7 +34,7 @@ impl<T: Serialize> Serialize for Option<T> {
         match self {
             Some(e) => {
                 let written = writer.write(&[1])?;
-                #[cfg(not(hax))]
+                hax_lib::assume!(written == 1);
                 debug_assert_eq!(written, 1);
                 e.tls_serialize(writer).map(|l| {
                     hax_lib::fstar!("admit ()"); // overflow

--- a/tls_codec/src/primitives.rs
+++ b/tls_codec/src/primitives.rs
@@ -36,10 +36,9 @@ impl<T: Serialize> Serialize for Option<T> {
                 let written = writer.write(&[1])?;
                 hax_lib::assume!(written == 1);
                 debug_assert_eq!(written, 1);
-                e.tls_serialize(writer).map(|l| {
-                    hax_lib::fstar!("admit ()"); // overflow
-                    l + 1
-                })
+                e.tls_serialize(writer)?
+                    .checked_add(1)
+                    .ok_or(Error::LibraryError)
             }
             None => {
                 writer.write_all(&[0])?;
@@ -54,8 +53,11 @@ impl<T: SerializeBytes> SerializeBytes for Option<T> {
     fn tls_serialize(&self) -> Result<Vec<u8>, Error> {
         match self {
             Some(e) => {
-                hax_lib::fstar!("admit ()"); // overflow
-                let mut out = Vec::with_capacity(e.tls_serialized_len() + 1);
+                let mut out = Vec::with_capacity(
+                    e.tls_serialized_len()
+                        .checked_add(1)
+                        .ok_or(Error::LibraryError)?,
+                );
                 out.push(1);
                 // Not inlining serialized_e is a workaround for
                 // https://github.com/cryspen/hax/issues/1584
@@ -243,10 +245,10 @@ where
     #[inline(always)]
     fn tls_serialize<W: Write>(&self, writer: &mut W) -> Result<usize, Error> {
         let written = self.0.tls_serialize(writer)?;
-        self.1.tls_serialize(writer).map(|l| {
-            hax_lib::fstar!("admit ()"); // overflow
-            l + written
-        })
+        self.1
+            .tls_serialize(writer)?
+            .checked_add(written)
+            .ok_or(Error::LibraryError)
     }
 }
 
@@ -303,10 +305,14 @@ where
     #[cfg(feature = "std")]
     #[inline(always)]
     fn tls_serialize<W: Write>(&self, writer: &mut W) -> Result<usize, Error> {
-        let mut written = self.0.tls_serialize(writer)?;
-        hax_lib::fstar!("admit ()"); // overflow
-        written += self.1.tls_serialize(writer)?;
-        self.2.tls_serialize(writer).map(|l| l + written)
+        let written = self.0.tls_serialize(writer)?;
+        let written = written
+            .checked_add(self.1.tls_serialize(writer)?)
+            .ok_or(Error::LibraryError)?;
+        self.2
+            .tls_serialize(writer)?
+            .checked_add(written)
+            .ok_or(Error::LibraryError)
     }
 }
 

--- a/tls_codec/src/quic_vec.rs
+++ b/tls_codec/src/quic_vec.rs
@@ -22,7 +22,7 @@ use arbitrary::{Arbitrary, Unstructured};
 #[cfg(feature = "serde")]
 use serde::{Deserialize as SerdeDeserialize, Serialize as SerdeSerialize};
 
-use crate::{DeserializeBytes, Error, SerializeBytes, Size};
+use crate::{DeserializeBytes, Error, SerializeBytes, Size, primitives::add};
 
 #[cfg(not(feature = "mls"))]
 #[hax_lib::fstar::verification_status(lax)] // Need lemma for (1 << 62) >= 1
@@ -180,9 +180,7 @@ impl<T: DeserializeBytes> DeserializeBytes for Vec<T> {
             hax_lib::loop_invariant!(read >= len_len);
             let (element, next_remainder) = T::tls_deserialize_bytes(remainder)?;
             remainder = next_remainder;
-            read = read
-                .checked_add(element.tls_serialized_len())
-                .ok_or(Error::LibraryError)?;
+            read = add!(read, element.tls_serialized_len());
             result.push(element);
         }
         Ok((result, remainder))
@@ -360,20 +358,30 @@ impl From<VLBytes> for Vec<u8> {
 }
 
 #[inline(always)]
-fn tls_serialize_bytes_len(bytes: &[u8]) -> Option<usize> {
+fn tls_serialize_bytes_len_checked(bytes: &[u8]) -> Option<usize> {
     let content_length = bytes.len();
     let len_len = length_encoding_bytes(content_length as u64).ok()?;
     content_length.checked_add(len_len)
 }
 
+#[inline(always)]
+fn tls_serialize_bytes_len(bytes: &[u8]) -> usize {
+    let content_length = bytes.len();
+    let len_len = length_encoding_bytes(content_length as u64).unwrap_or({
+        // We can't do anything about the error. Let's say there's no content.
+        0
+    });
+    content_length + len_len
+}
+
 impl Size for VLBytes {
     #[inline(always)]
     fn tls_serialized_len(&self) -> usize {
-        tls_serialize_bytes_len(self.as_slice()).unwrap_or(0)
+        tls_serialize_bytes_len(self.as_slice())
     }
     #[inline(always)]
     fn tls_serialized_len_checked(&self) -> Option<usize> {
-        tls_serialize_bytes_len(self.as_slice())
+        tls_serialize_bytes_len_checked(self.as_slice())
     }
 }
 
@@ -499,22 +507,22 @@ impl VLByteSlice<'_> {
 impl Size for &VLByteSlice<'_> {
     #[inline]
     fn tls_serialized_len(&self) -> usize {
-        tls_serialize_bytes_len(self.0).unwrap_or(0)
+        tls_serialize_bytes_len(self.0)
     }
     #[inline]
     fn tls_serialized_len_checked(&self) -> Option<usize> {
-        tls_serialize_bytes_len(self.0)
+        tls_serialize_bytes_len_checked(self.0)
     }
 }
 
 impl Size for VLByteSlice<'_> {
     #[inline]
     fn tls_serialized_len_checked(&self) -> Option<usize> {
-        tls_serialize_bytes_len(self.0)
+        tls_serialize_bytes_len_checked(self.0)
     }
     #[inline]
     fn tls_serialized_len(&self) -> usize {
-        tls_serialize_bytes_len(self.0).unwrap_or(0)
+        tls_serialize_bytes_len(self.0)
     }
 }
 
@@ -569,9 +577,7 @@ pub mod rw {
             while (read - len_len) < length {
                 hax_lib::loop_invariant!(read >= len_len);
                 let element = T::tls_deserialize(bytes)?;
-                read = read
-                    .checked_add(element.tls_serialized_len())
-                    .ok_or(Error::LibraryError)?;
+                read = add!(read, element.tls_serialized_len());
                 result.push(element);
             }
             Ok(result)
@@ -661,9 +667,7 @@ mod rw_bytes {
         // Now serialize the elements
         writer.write_all(bytes)?;
 
-        content_length
-            .checked_add(len_len)
-            .ok_or(Error::LibraryError)
+        Ok(add!(content_length, len_len))
     }
 
     impl Serialize for VLBytes {

--- a/tls_codec/src/quic_vec.rs
+++ b/tls_codec/src/quic_vec.rs
@@ -235,8 +235,8 @@ impl<T: SerializeBytes> SerializeBytes for Vec<T> {
 
 fn serialized_len_checked_slice<T: Size>(s: &[T]) -> Option<usize> {
     hax_lib::fstar!("admit ()"); // https://github.com/cryspen/hax/issues/1700
-    let content_length = s.iter().fold(Some(0usize), |acc, e| {
-        acc?.checked_add(e.tls_serialized_len_checked()?)
+    let content_length = s.iter().try_fold(0usize, |acc, e| {
+        acc.checked_add(e.tls_serialized_len_checked()?)
     })?;
     let len_len = length_encoding_bytes(content_length as u64).ok()?;
     content_length.checked_add(len_len)

--- a/tls_codec/src/quic_vec.rs
+++ b/tls_codec/src/quic_vec.rs
@@ -25,6 +25,7 @@ use serde::{Deserialize as SerdeDeserialize, Serialize as SerdeSerialize};
 use crate::{DeserializeBytes, Error, SerializeBytes, Size};
 
 #[cfg(not(feature = "mls"))]
+#[hax_lib::fstar::verification_status(lax)] // Need lemma for (1 << 62) >= 1
 const MAX_LEN: u64 = (1 << 62) - 1;
 #[cfg(not(feature = "mls"))]
 const MAX_LEN_LEN_LOG: usize = 3;
@@ -50,6 +51,7 @@ fn calculate_length(len_len_byte: u8) -> Result<(usize, usize), Error> {
     let length: usize = (len_len_byte & 0x3F).into();
     let len_len_log = (len_len_byte >> 6).into();
     if !cfg!(fuzzing) {
+        #[cfg(not(hax))]
         debug_assert!(len_len_log <= MAX_LEN_LEN_LOG);
     }
     if len_len_log > MAX_LEN_LEN_LOG {
@@ -87,6 +89,7 @@ fn read_variable_length_bytes(bytes: &[u8]) -> Result<((usize, usize), &[u8]), E
 #[inline(always)]
 fn length_encoding_bytes(length: u64) -> Result<usize, Error> {
     if !cfg!(fuzzing) {
+        #[cfg(not(hax))]
         debug_assert!(length <= MAX_LEN);
     }
     if length > MAX_LEN {
@@ -129,6 +132,7 @@ pub fn write_variable_length(content_length: usize) -> Result<Vec<u8>, Error> {
     }
     let mut len = content_length;
     let l = length_bytes.len();
+    hax_lib::fstar!("admit ()"); // underflows
     for i in 0..l {
         // Not using |= is a workaround for https://github.com/cryspen/hax/issues/1512
         length_bytes[l - i - 1] = length_bytes[l - i - 1] | ((len & 0xFF) as u8);
@@ -165,8 +169,10 @@ impl<T: DeserializeBytes> DeserializeBytes for Vec<T> {
         let mut result = Vec::new();
         let mut read = len_len;
         while (read - len_len) < length {
+            hax_lib::loop_invariant!(read >= len_len);
             let (element, next_remainder) = T::tls_deserialize_bytes(remainder)?;
             remainder = next_remainder;
+            hax_lib::assume!(read < 1000 && element.tls_serialized_len() < 1000); // overflow
             read += element.tls_serialized_len();
             result.push(element);
         }
@@ -180,6 +186,8 @@ impl<T: SerializeBytes> SerializeBytes for &[T] {
         // We need to pre-compute the length of the content.
         // This requires more computations but the other option would be to buffer
         // the entire content, which can end up requiring a lot of memory.
+
+        hax_lib::fstar!("admit ()"); // https://github.com/cryspen/hax/issues/1700
         let content_length = self.iter().fold(0, |acc, e| acc + e.tls_serialized_len());
         let mut length = write_variable_length(content_length)?;
         let len_len = length.len();
@@ -219,6 +227,7 @@ impl<T: SerializeBytes> SerializeBytes for Vec<T> {
 impl<T: Size> Size for &[T] {
     #[inline(always)]
     fn tls_serialized_len(&self) -> usize {
+        hax_lib::fstar!("admit ()"); // https://github.com/cryspen/hax/issues/1700
         let content_length = self.iter().fold(0, |acc, e| acc + e.tls_serialized_len());
         let len_len = length_encoding_bytes(content_length as u64).unwrap_or({
             // We can't do anything about the error unless we change the trait.
@@ -339,6 +348,7 @@ fn tls_serialize_bytes_len(bytes: &[u8]) -> usize {
         // We can't do anything about the error. Let's say there's no content.
         0
     });
+    hax_lib::fstar!("admit ()"); // overflow
     content_length + len_len
 }
 
@@ -352,6 +362,7 @@ impl Size for VLBytes {
 impl DeserializeBytes for VLBytes {
     #[inline(always)]
     fn tls_deserialize_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
+        hax_lib::fstar!("admit ()");
         let ((length, _), remainder) = read_variable_length_bytes(bytes)?;
         if length == 0 {
             return Ok((Self::new(vec![]), remainder));
@@ -524,6 +535,7 @@ pub mod rw {
 
             let mut result = Vec::new();
             let mut read = len_len;
+            hax_lib::fstar!("admit ()"); // underflow
             while (read - len_len) < length {
                 let element = T::tls_deserialize(bytes)?;
                 read += element.tls_serialized_len();
@@ -557,6 +569,7 @@ pub mod rw {
             // We need to pre-compute the length of the content.
             // This requires more computations but the other option would be to buffer
             // the entire content, which can end up requiring a lot of memory.
+            hax_lib::fstar!("admit ()"); // https://github.com/cryspen/hax/issues/1700
             let content_length = self.iter().fold(0, |acc, e| acc + e.tls_serialized_len());
             let len_len = write_length(writer, content_length)?;
 
@@ -597,6 +610,8 @@ mod rw_bytes {
         // large and write it out.
         let content_length = bytes.len();
 
+        hax_lib::fstar!("admit ()");
+
         if !cfg!(fuzzing) {
             debug_assert!(
                 content_length as u64 <= MAX_LEN,
@@ -633,6 +648,7 @@ mod rw_bytes {
 
     impl Deserialize for VLBytes {
         fn tls_deserialize<R: std::io::Read>(bytes: &mut R) -> Result<Self, Error> {
+            hax_lib::fstar!("admit ()");
             let (length, _) = rw::read_length(bytes)?;
             if length == 0 {
                 return Ok(Self::new(vec![]));

--- a/tls_codec/src/quic_vec.rs
+++ b/tls_codec/src/quic_vec.rs
@@ -233,24 +233,26 @@ impl<T: SerializeBytes> SerializeBytes for Vec<T> {
     }
 }
 
-#[allow(clippy::manual_try_fold)]
-fn serialized_len_checked_slice<T: Size>(s: &[T]) -> Option<usize> {
-    hax_lib::fstar!("admit ()"); // https://github.com/cryspen/hax/issues/1700
-    let content_length = s.iter().fold(Some(0usize), |acc, e| {
-        acc?.checked_add(e.tls_serialized_len_checked()?)
-    })?;
-    let len_len = length_encoding_bytes(content_length as u64).ok()?;
-    content_length.checked_add(len_len)
-}
-
 impl<T: Size> Size for &[T] {
     #[inline(always)]
+    #[allow(clippy::manual_try_fold)]
     fn tls_serialized_len_checked(&self) -> Option<usize> {
-        serialized_len_checked_slice(self)
+        hax_lib::fstar!("admit ()"); // https://github.com/cryspen/hax/issues/1700
+        let content_length = self.iter().fold(Some(0usize), |acc, e| {
+            acc?.checked_add(e.tls_serialized_len_checked()?)
+        })?;
+        let len_len = length_encoding_bytes(content_length as u64).ok()?;
+        content_length.checked_add(len_len)
     }
     #[inline(always)]
     fn tls_serialized_len(&self) -> usize {
-        serialized_len_checked_slice(self).unwrap_or(0)
+        let content_length = self.iter().fold(0, |acc, e| acc + e.tls_serialized_len());
+        let len_len = length_encoding_bytes(content_length as u64).unwrap_or({
+            // We can't do anything about the error unless we change the trait.
+            // Let's say there's no content for now.
+            0
+        });
+        content_length + len_len
     }
 }
 

--- a/tls_codec/src/quic_vec.rs
+++ b/tls_codec/src/quic_vec.rs
@@ -147,12 +147,20 @@ impl<T: Size> Size for Vec<T> {
     fn tls_serialized_len(&self) -> usize {
         self.as_slice().tls_serialized_len()
     }
+    #[inline(always)]
+    fn tls_serialized_len_checked(&self) -> Option<usize> {
+        self.as_slice().tls_serialized_len_checked()
+    }
 }
 
 impl<T: Size> Size for &Vec<T> {
     #[inline(always)]
     fn tls_serialized_len(&self) -> usize {
         (*self).tls_serialized_len()
+    }
+    #[inline(always)]
+    fn tls_serialized_len_checked(&self) -> Option<usize> {
+        (*self).tls_serialized_len_checked()
     }
 }
 
@@ -225,17 +233,23 @@ impl<T: SerializeBytes> SerializeBytes for Vec<T> {
     }
 }
 
+fn serialized_len_checked_slice<T: Size>(s: &[T]) -> Option<usize> {
+    hax_lib::fstar!("admit ()"); // https://github.com/cryspen/hax/issues/1700
+    let content_length = s.iter().fold(Some(0usize), |acc, e| {
+        acc?.checked_add(e.tls_serialized_len_checked()?)
+    })?;
+    let len_len = length_encoding_bytes(content_length as u64).ok()?;
+    content_length.checked_add(len_len)
+}
+
 impl<T: Size> Size for &[T] {
     #[inline(always)]
+    fn tls_serialized_len_checked(&self) -> Option<usize> {
+        serialized_len_checked_slice(self)
+    }
+    #[inline(always)]
     fn tls_serialized_len(&self) -> usize {
-        hax_lib::fstar!("admit ()"); // https://github.com/cryspen/hax/issues/1700
-        let content_length = self.iter().fold(0, |acc, e| acc + e.tls_serialized_len());
-        let len_len = length_encoding_bytes(content_length as u64).unwrap_or({
-            // We can't do anything about the error unless we change the trait.
-            // Let's say there's no content for now.
-            0
-        });
-        content_length + len_len
+        serialized_len_checked_slice(self).unwrap_or(0)
     }
 }
 
@@ -343,19 +357,19 @@ impl From<VLBytes> for Vec<u8> {
 }
 
 #[inline(always)]
-fn tls_serialize_bytes_len(bytes: &[u8]) -> usize {
+fn tls_serialize_bytes_len(bytes: &[u8]) -> Option<usize> {
     let content_length = bytes.len();
-    let len_len = length_encoding_bytes(content_length as u64).unwrap_or({
-        // We can't do anything about the error. Let's say there's no content.
-        0
-    });
-    hax_lib::fstar!("admit ()"); // overflow
-    content_length + len_len
+    let len_len = length_encoding_bytes(content_length as u64).ok()?;
+    content_length.checked_add(len_len)
 }
 
 impl Size for VLBytes {
     #[inline(always)]
     fn tls_serialized_len(&self) -> usize {
+        tls_serialize_bytes_len(self.as_slice()).unwrap_or(0)
+    }
+    #[inline(always)]
+    fn tls_serialized_len_checked(&self) -> Option<usize> {
         tls_serialize_bytes_len(self.as_slice())
     }
 }
@@ -403,6 +417,10 @@ impl Size for &VLBytes {
     #[inline(always)]
     fn tls_serialized_len(&self) -> usize {
         (*self).tls_serialized_len()
+    }
+    #[inline(always)]
+    fn tls_serialized_len_checked(&self) -> Option<usize> {
+        (*self).tls_serialized_len_checked()
     }
 }
 
@@ -478,14 +496,22 @@ impl VLByteSlice<'_> {
 impl Size for &VLByteSlice<'_> {
     #[inline]
     fn tls_serialized_len(&self) -> usize {
+        tls_serialize_bytes_len(self.0).unwrap_or(0)
+    }
+    #[inline]
+    fn tls_serialized_len_checked(&self) -> Option<usize> {
         tls_serialize_bytes_len(self.0)
     }
 }
 
 impl Size for VLByteSlice<'_> {
     #[inline]
-    fn tls_serialized_len(&self) -> usize {
+    fn tls_serialized_len_checked(&self) -> Option<usize> {
         tls_serialize_bytes_len(self.0)
+    }
+    #[inline]
+    fn tls_serialized_len(&self) -> usize {
+        tls_serialize_bytes_len(self.0).unwrap_or(0)
     }
 }
 
@@ -733,6 +759,9 @@ mod secret_bytes {
     impl Size for SecretVLBytes {
         fn tls_serialized_len(&self) -> usize {
             self.0.tls_serialized_len()
+        }
+        fn tls_serialized_len_checked(&self) -> Option<usize> {
+            self.0.tls_serialized_len_checked()
         }
     }
 

--- a/tls_codec/src/quic_vec.rs
+++ b/tls_codec/src/quic_vec.rs
@@ -537,10 +537,12 @@ pub mod rw {
 
             let mut result = Vec::new();
             let mut read = len_len;
-            hax_lib::fstar!("admit ()"); // underflow
             while (read - len_len) < length {
+                hax_lib::loop_invariant!(read >= len_len);
                 let element = T::tls_deserialize(bytes)?;
-                read += element.tls_serialized_len();
+                read = read
+                    .checked_add(element.tls_serialized_len())
+                    .ok_or(Error::LibraryError)?;
                 result.push(element);
             }
             Ok(result)

--- a/tls_codec/src/quic_vec.rs
+++ b/tls_codec/src/quic_vec.rs
@@ -172,7 +172,7 @@ impl<T: DeserializeBytes> DeserializeBytes for Vec<T> {
             hax_lib::loop_invariant!(read >= len_len);
             let (element, next_remainder) = T::tls_deserialize_bytes(remainder)?;
             remainder = next_remainder;
-            hax_lib::assume!(read < 1000 && element.tls_serialized_len() < 1000); // overflow
+            hax_lib::fstar!("admit ()"); // overflow
             read += element.tls_serialized_len();
             result.push(element);
         }
@@ -362,13 +362,13 @@ impl Size for VLBytes {
 impl DeserializeBytes for VLBytes {
     #[inline(always)]
     fn tls_deserialize_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
-        hax_lib::fstar!("admit ()");
         let ((length, _), remainder) = read_variable_length_bytes(bytes)?;
         if length == 0 {
             return Ok((Self::new(vec![]), remainder));
         }
 
         if !cfg!(fuzzing) {
+            #[cfg(not(hax))]
             debug_assert!(
                 length <= MAX_LEN as usize,
                 "Trying to allocate {length} bytes. Only {MAX_LEN} allowed.",
@@ -379,11 +379,12 @@ impl DeserializeBytes for VLBytes {
                 "Trying to allocate {length} bytes. Only {MAX_LEN} allowed.",
             )));
         }
-        match remainder.get(..length).ok_or(Error::EndOfStream) {
-            Ok(vec) => Ok((Self { vec: vec.to_vec() }, &remainder[length..])),
+        match remainder.split_at_checked(length).ok_or(Error::EndOfStream) {
+            Ok((vec, remainder)) => Ok((Self { vec: vec.to_vec() }, remainder)),
             Err(_e) => {
                 let remaining_len = remainder.len();
                 if !cfg!(fuzzing) {
+                    #[cfg(not(hax))]
                     debug_assert_eq!(
                         remaining_len, length,
                         "Expected to read {length} bytes but {remaining_len} were read.",
@@ -610,9 +611,8 @@ mod rw_bytes {
         // large and write it out.
         let content_length = bytes.len();
 
-        hax_lib::fstar!("admit ()");
-
         if !cfg!(fuzzing) {
+            #[cfg(not(hax))]
             debug_assert!(
                 content_length as u64 <= MAX_LEN,
                 "Vector can't be encoded. It's too large. {content_length} >= {MAX_LEN}",
@@ -628,6 +628,8 @@ mod rw_bytes {
 
         // Now serialize the elements
         writer.write_all(bytes)?;
+
+        hax_lib::fstar!("admit ()"); // overflow
 
         Ok(content_length + len_len)
     }
@@ -648,13 +650,13 @@ mod rw_bytes {
 
     impl Deserialize for VLBytes {
         fn tls_deserialize<R: std::io::Read>(bytes: &mut R) -> Result<Self, Error> {
-            hax_lib::fstar!("admit ()");
             let (length, _) = rw::read_length(bytes)?;
             if length == 0 {
                 return Ok(Self::new(vec![]));
             }
 
             if !cfg!(fuzzing) {
+                #[cfg(not(hax))]
                 debug_assert!(
                     length <= MAX_LEN as usize,
                     "Trying to allocate {length} bytes. Only {MAX_LEN} allowed.",

--- a/tls_codec/src/quic_vec.rs
+++ b/tls_codec/src/quic_vec.rs
@@ -132,8 +132,8 @@ pub fn write_variable_length(content_length: usize) -> Result<Vec<u8>, Error> {
     }
     let mut len = content_length;
     let l = length_bytes.len();
-    hax_lib::fstar!("admit ()"); // underflows
     for i in 0..l {
+        hax_lib::loop_invariant!(|_: usize| length_bytes.len() == l);
         // Not using |= is a workaround for https://github.com/cryspen/hax/issues/1512
         length_bytes[l - i - 1] = length_bytes[l - i - 1] | ((len & 0xFF) as u8);
         len >>= 8;
@@ -172,8 +172,9 @@ impl<T: DeserializeBytes> DeserializeBytes for Vec<T> {
             hax_lib::loop_invariant!(read >= len_len);
             let (element, next_remainder) = T::tls_deserialize_bytes(remainder)?;
             remainder = next_remainder;
-            hax_lib::fstar!("admit ()"); // overflow
-            read += element.tls_serialized_len();
+            read = read
+                .checked_add(element.tls_serialized_len())
+                .ok_or(Error::LibraryError)?;
             result.push(element);
         }
         Ok((result, remainder))
@@ -629,9 +630,9 @@ mod rw_bytes {
         // Now serialize the elements
         writer.write_all(bytes)?;
 
-        hax_lib::fstar!("admit ()"); // overflow
-
-        Ok(content_length + len_len)
+        content_length
+            .checked_add(len_len)
+            .ok_or(Error::LibraryError)
     }
 
     impl Serialize for VLBytes {

--- a/tls_codec/src/quic_vec.rs
+++ b/tls_codec/src/quic_vec.rs
@@ -24,6 +24,9 @@ use serde::{Deserialize as SerdeDeserialize, Serialize as SerdeSerialize};
 
 use crate::{DeserializeBytes, Error, SerializeBytes, Size, primitives::add};
 
+#[cfg(hax)]
+use hax_lib::ToInt;
+
 #[cfg(not(feature = "mls"))]
 #[hax_lib::fstar::verification_status(lax)] // Need lemma for (1 << 62) >= 1
 const MAX_LEN: u64 = (1 << 62) - 1;
@@ -181,6 +184,7 @@ impl<T: DeserializeBytes> DeserializeBytes for Vec<T> {
             let (element, next_remainder) = T::tls_deserialize_bytes(remainder)?;
             remainder = next_remainder;
             read = add!(read, element.tls_serialized_len());
+            hax_lib::assume!(result.len() < usize::MAX);
             result.push(element);
         }
         Ok((result, remainder))
@@ -244,12 +248,16 @@ impl<T: Size> Size for &[T] {
     }
     #[inline(always)]
     fn tls_serialized_len(&self) -> usize {
-        let content_length = self.iter().fold(0, |acc, e| acc + e.tls_serialized_len());
+        let content_length = self.iter().fold(0, |acc, e| {
+            hax_lib::assume!(acc.to_int() + e.tls_serialized_len().to_int() <= usize::MAX.to_int());
+            acc + e.tls_serialized_len()
+        });
         let len_len = length_encoding_bytes(content_length as u64).unwrap_or({
             // We can't do anything about the error unless we change the trait.
             // Let's say there's no content for now.
             0
         });
+        hax_lib::assume!(content_length.to_int() + len_len.to_int() <= usize::MAX.to_int());
         content_length + len_len
     }
 }
@@ -339,6 +347,7 @@ impl VLBytes {
     /// Add an element to this.
     #[inline]
     pub fn push(&mut self, v: u8) {
+        hax_lib::assume!(self.vec.len() < usize::MAX);
         self.vec.push(v)
     }
 
@@ -371,6 +380,7 @@ fn tls_serialize_bytes_len(bytes: &[u8]) -> usize {
         // We can't do anything about the error. Let's say there's no content.
         0
     });
+    hax_lib::assume!(content_length.to_int() + len_len.to_int() <= usize::MAX.to_int());
     content_length + len_len
 }
 
@@ -578,6 +588,7 @@ pub mod rw {
                 hax_lib::loop_invariant!(read >= len_len);
                 let element = T::tls_deserialize(bytes)?;
                 read = add!(read, element.tls_serialized_len());
+                hax_lib::assume!(result.len() < usize::MAX);
                 result.push(element);
             }
             Ok(result)
@@ -751,6 +762,7 @@ mod secret_bytes {
         /// Add an element to this.
         #[inline]
         pub fn push(&mut self, v: u8) {
+            hax_lib::assume!(self.0.vec.len() < usize::MAX);
             self.0.vec.push(v)
         }
 

--- a/tls_codec/src/quic_vec.rs
+++ b/tls_codec/src/quic_vec.rs
@@ -233,10 +233,11 @@ impl<T: SerializeBytes> SerializeBytes for Vec<T> {
     }
 }
 
+#[allow(clippy::manual_try_fold)]
 fn serialized_len_checked_slice<T: Size>(s: &[T]) -> Option<usize> {
     hax_lib::fstar!("admit ()"); // https://github.com/cryspen/hax/issues/1700
-    let content_length = s.iter().try_fold(0usize, |acc, e| {
-        acc.checked_add(e.tls_serialized_len_checked()?)
+    let content_length = s.iter().fold(Some(0usize), |acc, e| {
+        acc?.checked_add(e.tls_serialized_len_checked()?)
     })?;
     let len_len = length_encoding_bytes(content_length as u64).ok()?;
     content_length.checked_add(len_len)

--- a/tls_codec/src/tls_vec.rs
+++ b/tls_codec/src/tls_vec.rs
@@ -98,7 +98,7 @@ macro_rules! impl_deserialize {
             while (read - len_len) < len.try_into().unwrap() {
                 hax_lib::loop_invariant!(read >= len_len);
                 let element = T::tls_deserialize(bytes)?;
-                hax_lib::assume!(read < 1000 && element.tls_serialized_len() < 1000); // overflow
+                hax_lib::fstar!("admit ()"); // overflow
                 read += element.tls_serialized_len();
                 result.push(element);
             }
@@ -119,7 +119,7 @@ macro_rules! impl_deserialize_bytes {
                 hax_lib::loop_invariant!(read >= len_len);
                 let (element, next_remainder) = T::tls_deserialize_bytes(remainder)?;
                 remainder = next_remainder;
-                hax_lib::assume!(read < 1000 && element.tls_serialized_len() < 1000); // overflow
+                hax_lib::fstar!("admit ()"); // overflow
                 read += element.tls_serialized_len();
                 result.push(element);
             }
@@ -180,7 +180,7 @@ macro_rules! impl_serialize_common {
         $(#[$std_enabled])?
         fn get_content_lengths(&$self) -> Result<(usize, usize), Error> {
             let tls_serialized_len = $self.tls_serialized_len();
-            hax_lib::assume!(tls_serialized_len > $len_len);
+            hax_lib::assume!(tls_serialized_len > $len_len); // underflow
             let byte_length = tls_serialized_len - $len_len;
             let max_len = <$size>::MAX.try_into().unwrap();
             #[cfg(not(hax))]
@@ -449,19 +449,19 @@ macro_rules! impl_tls_vec_generic {
             }
         }
 
-        #[hax_lib::opaque] // index precondition
         impl<T: $($bounds + )*> core::ops::Index<usize> for $name<T> {
             type Output = T;
 
             #[inline]
             fn index(&self, i: usize) -> &T {
+                hax_lib::fstar!("admit ()"); // index precondition
                 self.vec.index(i)
             }
         }
 
-        #[hax_lib::opaque] // translation uses =., why?
         impl<T: $($bounds + )* core::cmp::PartialEq> core::cmp::PartialEq for $name<T> {
             fn eq(&self, other: &Self) -> bool {
+                hax_lib::fstar!("admit ()"); // https://github.com/cryspen/hax/issues/1704
                 self.vec.eq(&other.vec)
             }
         }

--- a/tls_codec/src/tls_vec.rs
+++ b/tls_codec/src/tls_vec.rs
@@ -65,7 +65,7 @@ macro_rules! impl_byte_deserialize {
         #[inline(always)]
         fn deserialize_bytes_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
             let (type_len, remainder) = <$size>::tls_deserialize_bytes(bytes)?;
-            let len = type_len.try_into().unwrap();
+            let len: usize = type_len.try_into().unwrap();
             // When fuzzing we limit the maximum size to allocate.
             // XXX: We should think about a configurable limit for the allocation
             //      here.
@@ -76,10 +76,8 @@ macro_rules! impl_byte_deserialize {
                     u16::MAX
                 )));
             }
-            hax_lib::fstar!("admit ()"); // overflow
-            let vec = bytes
-                .get($len_len..len + $len_len)
-                .ok_or(Error::EndOfStream)?;
+            let end = len.checked_add($len_len).ok_or(Error::LibraryError)?;
+            let vec = bytes.get($len_len..end).ok_or(Error::EndOfStream)?;
             let result = Self { vec: vec.to_vec() };
             Ok((result, &remainder.get(len..).ok_or(Error::EndOfStream)?))
         }
@@ -98,8 +96,9 @@ macro_rules! impl_deserialize {
             while (read - len_len) < len.try_into().unwrap() {
                 hax_lib::loop_invariant!(read >= len_len);
                 let element = T::tls_deserialize(bytes)?;
-                hax_lib::fstar!("admit ()"); // overflow
-                read += element.tls_serialized_len();
+                read = read
+                    .checked_add(element.tls_serialized_len())
+                    .ok_or(Error::LibraryError)?;
                 result.push(element);
             }
             Ok(result)
@@ -119,8 +118,9 @@ macro_rules! impl_deserialize_bytes {
                 hax_lib::loop_invariant!(read >= len_len);
                 let (element, next_remainder) = T::tls_deserialize_bytes(remainder)?;
                 remainder = next_remainder;
-                hax_lib::fstar!("admit ()"); // overflow
-                read += element.tls_serialized_len();
+                read = read
+                    .checked_add(element.tls_serialized_len())
+                    .ok_or(Error::LibraryError)?;
                 result.push(element);
             }
             Ok((result, remainder))
@@ -165,9 +165,8 @@ macro_rules! impl_byte_serialize {
             hax_lib::fstar!("admit ()"); // Need to prove unwrap for usize to U24
             let mut written = <$size as Serialize>::tls_serialize(&<$size>::try_from(byte_length).unwrap(), writer)?;
 
-            hax_lib::fstar!("admit ()"); // overflow
             // Now serialize the elements
-            written += writer.write($self.as_slice())?;
+            written = written.checked_add(writer.write($self.as_slice())?).ok_or(Error::LibraryError)?;
 
             $self.assert_written_bytes(tls_serialized_len, written)?;
             Ok(written)
@@ -180,8 +179,7 @@ macro_rules! impl_serialize_common {
         $(#[$std_enabled])?
         fn get_content_lengths(&$self) -> Result<(usize, usize), Error> {
             let tls_serialized_len = $self.tls_serialized_len();
-            hax_lib::assume!(tls_serialized_len > $len_len); // underflow
-            let byte_length = tls_serialized_len - $len_len;
+            let byte_length = tls_serialized_len.checked_sub($len_len).ok_or(Error::InvalidVectorLength)?;
             let max_len = <$size>::MAX.try_into().unwrap();
             #[cfg(not(hax))]
             debug_assert!(

--- a/tls_codec/src/tls_vec.rs
+++ b/tls_codec/src/tls_vec.rs
@@ -447,12 +447,13 @@ macro_rules! impl_tls_vec_generic {
             }
         }
 
+        #[hax_lib::attributes]
         impl<T: $($bounds + )*> core::ops::Index<usize> for $name<T> {
             type Output = T;
 
             #[inline]
+            #[hax_lib::requires(i < self.vec.len())]
             fn index(&self, i: usize) -> &T {
-                hax_lib::fstar!("admit ()"); // index precondition
                 self.vec.index(i)
             }
         }
@@ -648,12 +649,13 @@ macro_rules! impl_tls_vec {
             }
         }
 
+        #[hax_lib::attributes]
         impl core::ops::Index<usize> for $name {
             type Output = u8;
 
             #[inline]
+            #[hax_lib::requires(i < self.vec.len())]
             fn index(&self, i: usize) -> &u8 {
-                hax_lib::fstar!("admit ()"); // index precondition
                 self.vec.index(i)
             }
         }

--- a/tls_codec/src/tls_vec.rs
+++ b/tls_codec/src/tls_vec.rs
@@ -20,6 +20,7 @@ macro_rules! impl_size {
         /// The serialized len
         #[inline(always)]
         fn tls_serialized_length(&$self) -> usize {
+            hax_lib::fstar!("admit ()"); // https://github.com/cryspen/hax/issues/1700
             $self.as_slice()
                 .iter()
                 .fold($len_len, |acc, e| acc + e.tls_serialized_len())
@@ -32,6 +33,7 @@ macro_rules! impl_byte_size {
         /// The serialized len
         #[inline(always)]
         fn tls_serialized_byte_length(&$self) -> usize {
+            hax_lib::fstar!("admit ()"); // overflow
             $self.as_slice().len() + $len_len
         }
     }
@@ -74,6 +76,7 @@ macro_rules! impl_byte_deserialize {
                     u16::MAX
                 )));
             }
+            hax_lib::fstar!("admit ()"); // overflow
             let vec = bytes
                 .get($len_len..len + $len_len)
                 .ok_or(Error::EndOfStream)?;
@@ -93,7 +96,9 @@ macro_rules! impl_deserialize {
             let mut read = len.tls_serialized_len();
             let len_len = read;
             while (read - len_len) < len.try_into().unwrap() {
+                hax_lib::loop_invariant!(read >= len_len);
                 let element = T::tls_deserialize(bytes)?;
+                hax_lib::assume!(read < 1000 && element.tls_serialized_len() < 1000); // overflow
                 read += element.tls_serialized_len();
                 result.push(element);
             }
@@ -111,8 +116,10 @@ macro_rules! impl_deserialize_bytes {
             let mut read = len.tls_serialized_len();
             let len_len = read;
             while (read - len_len) < len.try_into().unwrap() {
+                hax_lib::loop_invariant!(read >= len_len);
                 let (element, next_remainder) = T::tls_deserialize_bytes(remainder)?;
                 remainder = next_remainder;
+                hax_lib::assume!(read < 1000 && element.tls_serialized_len() < 1000); // overflow
                 read += element.tls_serialized_len();
                 result.push(element);
             }
@@ -130,8 +137,11 @@ macro_rules! impl_serialize {
             // large and write it out.
             let (tls_serialized_len, byte_length) = $self.get_content_lengths()?;
 
+            hax_lib::fstar!("admit ()"); // Need to prove unwrap for usize to U24
             let mut written = <$size as Serialize>::tls_serialize(&<$size>::try_from(byte_length).unwrap(), writer)?;
 
+
+            hax_lib::fstar!("admit ()"); // https://github.com/cryspen/hax/issues/1700
             // Now serialize the elements
             for e in $self.as_slice().iter() {
                 written += e.tls_serialize(writer)?;
@@ -152,8 +162,10 @@ macro_rules! impl_byte_serialize {
             // large and write it out.
             let (tls_serialized_len, byte_length) = $self.get_content_lengths()?;
 
+            hax_lib::fstar!("admit ()"); // Need to prove unwrap for usize to U24
             let mut written = <$size as Serialize>::tls_serialize(&<$size>::try_from(byte_length).unwrap(), writer)?;
 
+            hax_lib::fstar!("admit ()"); // overflow
             // Now serialize the elements
             written += writer.write($self.as_slice())?;
 
@@ -168,9 +180,10 @@ macro_rules! impl_serialize_common {
         $(#[$std_enabled])?
         fn get_content_lengths(&$self) -> Result<(usize, usize), Error> {
             let tls_serialized_len = $self.tls_serialized_len();
+            hax_lib::assume!(tls_serialized_len > $len_len);
             let byte_length = tls_serialized_len - $len_len;
-
             let max_len = <$size>::MAX.try_into().unwrap();
+            #[cfg(not(hax))]
             debug_assert!(
                 byte_length <= max_len,
                 "Vector length can't be encoded in the vector length a {} >= {}",
@@ -185,6 +198,7 @@ macro_rules! impl_serialize_common {
 
         $(#[$std_enabled])?
         fn assert_written_bytes(&$self, tls_serialized_len: usize, written: usize) -> Result<(), Error> {
+            #[cfg(not(hax))]
             debug_assert_eq!(
                 written, tls_serialized_len,
                 "{} bytes should have been serialized but {} were written",
@@ -207,6 +221,7 @@ macro_rules! impl_serialize_bytes_bytes {
             let (tls_serialized_len, byte_length) = $self.get_content_lengths()?;
 
             let mut vec = Vec::<u8>::with_capacity(tls_serialized_len);
+            hax_lib::fstar!("admit ()"); // Need to prove unwrap for usize to U24
             let length_vec = <$size as SerializeBytes>::tls_serialize(&byte_length.try_into().unwrap())?;
             let mut written = length_vec.len();
             vec.extend_from_slice(&length_vec);
@@ -434,6 +449,7 @@ macro_rules! impl_tls_vec_generic {
             }
         }
 
+        #[hax_lib::opaque] // index precondition
         impl<T: $($bounds + )*> core::ops::Index<usize> for $name<T> {
             type Output = T;
 
@@ -443,6 +459,7 @@ macro_rules! impl_tls_vec_generic {
             }
         }
 
+        #[hax_lib::opaque] // translation uses =., why?
         impl<T: $($bounds + )* core::cmp::PartialEq> core::cmp::PartialEq for $name<T> {
             fn eq(&self, other: &Self) -> bool {
                 self.vec.eq(&other.vec)
@@ -638,6 +655,7 @@ macro_rules! impl_tls_vec {
 
             #[inline]
             fn index(&self, i: usize) -> &u8 {
+                hax_lib::fstar!("admit ()"); // index precondition
                 self.vec.index(i)
             }
         }

--- a/tls_codec/src/tls_vec.rs
+++ b/tls_codec/src/tls_vec.rs
@@ -13,7 +13,9 @@ use serde::ser::SerializeStruct;
 use std::io::{Read, Write};
 use zeroize::Zeroize;
 
-use crate::{Deserialize, DeserializeBytes, Error, Serialize, SerializeBytes, Size, U24};
+use crate::{
+    Deserialize, DeserializeBytes, Error, Serialize, SerializeBytes, Size, U24, primitives::add,
+};
 
 macro_rules! impl_size {
     ($self:ident, $size:ty, $name:ident, $len_len:literal) => {
@@ -87,7 +89,7 @@ macro_rules! impl_byte_deserialize {
                     u16::MAX
                 )));
             }
-            let end = len.checked_add($len_len).ok_or(Error::LibraryError)?;
+            let end = add!(len, $len_len);
             let vec = bytes.get($len_len..end).ok_or(Error::EndOfStream)?;
             let result = Self { vec: vec.to_vec() };
             Ok((result, &remainder.get(len..).ok_or(Error::EndOfStream)?))
@@ -107,9 +109,7 @@ macro_rules! impl_deserialize {
             while (read - len_len) < len.try_into().unwrap() {
                 hax_lib::loop_invariant!(read >= len_len);
                 let element = T::tls_deserialize(bytes)?;
-                read = read
-                    .checked_add(element.tls_serialized_len())
-                    .ok_or(Error::LibraryError)?;
+                read = add!(read, element.tls_serialized_len());
                 result.push(element);
             }
             Ok(result)
@@ -129,9 +129,7 @@ macro_rules! impl_deserialize_bytes {
                 hax_lib::loop_invariant!(read >= len_len);
                 let (element, next_remainder) = T::tls_deserialize_bytes(remainder)?;
                 remainder = next_remainder;
-                read = read
-                    .checked_add(element.tls_serialized_len())
-                    .ok_or(Error::LibraryError)?;
+                read = add!(read, element.tls_serialized_len());
                 result.push(element);
             }
             Ok((result, remainder))
@@ -177,7 +175,7 @@ macro_rules! impl_byte_serialize {
             let mut written = <$size as Serialize>::tls_serialize(&<$size>::try_from(byte_length).unwrap(), writer)?;
 
             // Now serialize the elements
-            written = written.checked_add(writer.write($self.as_slice())?).ok_or(Error::LibraryError)?;
+            written = add!(written, writer.write($self.as_slice())?);
 
             $self.assert_written_bytes(tls_serialized_len, written)?;
             Ok(written)

--- a/tls_codec/src/tls_vec.rs
+++ b/tls_codec/src/tls_vec.rs
@@ -17,23 +17,35 @@ use crate::{Deserialize, DeserializeBytes, Error, Serialize, SerializeBytes, Siz
 
 macro_rules! impl_size {
     ($self:ident, $size:ty, $name:ident, $len_len:literal) => {
-        /// The serialized len
+        /// The serialized len, if there is no overflow
         #[inline(always)]
-        fn tls_serialized_length(&$self) -> Option<usize> {
+        fn tls_serialized_length_checked(&$self) -> Option<usize> {
             hax_lib::fstar!("admit ()"); // https://github.com/cryspen/hax/issues/1700
             $self.as_slice()
                 .iter()
                 .fold(Some($len_len), |acc, e| acc?.checked_add(e.tls_serialized_len_checked()?))
+        }
+        /// The serialized len
+        #[inline(always)]
+        fn tls_serialized_length(&$self) -> usize {
+            $self.as_slice()
+                .iter()
+                .fold($len_len, |acc, e| acc + e.tls_serialized_len())
         }
     }
 }
 
 macro_rules! impl_byte_size {
     ($self:ident, $size:ty, $name:ident, $len_len:literal) => {
+        /// The serialized len, if there is no addition overflow
+        #[inline(always)]
+        fn tls_serialized_byte_length_checked(&$self) -> Option<usize> {
+            $self.as_slice().len().checked_add($len_len)
+        }
         /// The serialized len
         #[inline(always)]
-        fn tls_serialized_byte_length(&$self) -> Option<usize> {
-            $self.as_slice().len().checked_add($len_len)
+        fn tls_serialized_byte_length(&$self) -> usize {
+            $self.as_slice().len() + $len_len
         }
     }
 }
@@ -246,11 +258,11 @@ macro_rules! impl_tls_vec_codec_generic {
         impl<T: $($bounds + )* Size> Size for $name<T> {
             #[inline]
             fn tls_serialized_len(&self) -> usize {
-                self.tls_serialized_length().unwrap_or(0)
+                self.tls_serialized_length()
             }
             #[inline]
             fn tls_serialized_len_checked(&self) -> Option<usize> {
-                self.tls_serialized_length()
+                self.tls_serialized_length_checked()
             }
         }
 
@@ -264,11 +276,11 @@ macro_rules! impl_tls_vec_codec_generic {
         impl<T: $($bounds + )* Size> Size for &$name<T> {
             #[inline]
             fn tls_serialized_len(&self) -> usize {
-                self.tls_serialized_length().unwrap_or(0)
+                self.tls_serialized_length()
             }
             #[inline]
             fn tls_serialized_len_checked(&self) -> Option<usize> {
-                self.tls_serialized_length()
+                self.tls_serialized_length_checked()
             }
         }
 
@@ -299,10 +311,10 @@ macro_rules! impl_tls_vec_codec_bytes {
         impl Size for $name {
             #[inline]
             fn tls_serialized_len_checked(&self) -> Option<usize> {
-                self.tls_serialized_byte_length()
+                self.tls_serialized_byte_length_checked()
             }
             fn tls_serialized_len(&self) -> usize {
-                self.tls_serialized_byte_length().unwrap_or(0)
+                self.tls_serialized_byte_length()
             }
         }
 
@@ -316,11 +328,11 @@ macro_rules! impl_tls_vec_codec_bytes {
         impl Size for &$name {
             #[inline]
             fn tls_serialized_len_checked(&self) -> Option<usize> {
-                self.tls_serialized_byte_length()
+                self.tls_serialized_byte_length_checked()
             }
             #[inline]
             fn tls_serialized_len(&self) -> usize {
-                self.tls_serialized_byte_length().unwrap_or(0)
+                self.tls_serialized_byte_length()
             }
         }
 
@@ -971,22 +983,22 @@ macro_rules! impl_tls_byte_slice {
         impl<'a> Size for &$name<'a> {
             #[inline]
             fn tls_serialized_len_checked(&self) -> Option<usize> {
-                self.tls_serialized_byte_length()
+                self.tls_serialized_byte_length_checked()
             }
             #[inline]
             fn tls_serialized_len(&self) -> usize {
-                self.tls_serialized_byte_length().unwrap_or(0)
+                self.tls_serialized_byte_length()
             }
         }
 
         impl<'a> Size for $name<'a> {
             #[inline]
             fn tls_serialized_len_checked(&self) -> Option<usize> {
-                self.tls_serialized_byte_length()
+                self.tls_serialized_byte_length_checked()
             }
             #[inline]
             fn tls_serialized_len(&self) -> usize {
-                self.tls_serialized_byte_length().unwrap_or(0)
+                self.tls_serialized_byte_length()
             }
         }
     };
@@ -1035,22 +1047,22 @@ macro_rules! impl_tls_slice {
         impl<'a, T: Size> Size for &$name<'a, T> {
             #[inline]
             fn tls_serialized_len_checked(&self) -> Option<usize> {
-                self.tls_serialized_length()
+                self.tls_serialized_length_checked()
             }
             #[inline]
             fn tls_serialized_len(&self) -> usize {
-                self.tls_serialized_length().unwrap_or(0)
+                self.tls_serialized_length()
             }
         }
 
         impl<'a, T: Size> Size for $name<'a, T> {
             #[inline]
             fn tls_serialized_len_checked(&self) -> Option<usize> {
-                self.tls_serialized_length()
+                self.tls_serialized_length_checked()
             }
             #[inline]
             fn tls_serialized_len(&self) -> usize {
-                self.tls_serialized_length().unwrap_or(0)
+                self.tls_serialized_length()
             }
         }
     };

--- a/tls_codec/src/tls_vec.rs
+++ b/tls_codec/src/tls_vec.rs
@@ -17,6 +17,9 @@ use crate::{
     Deserialize, DeserializeBytes, Error, Serialize, SerializeBytes, Size, U24, primitives::add,
 };
 
+#[cfg(hax)]
+use hax_lib::ToInt;
+
 macro_rules! impl_size {
     ($self:ident, $size:ty, $name:ident, $len_len:literal) => {
         /// The serialized len, if there is no overflow
@@ -32,7 +35,9 @@ macro_rules! impl_size {
         fn tls_serialized_length(&$self) -> usize {
             $self.as_slice()
                 .iter()
-                .fold($len_len, |acc, e| acc + e.tls_serialized_len())
+                .fold($len_len, |acc, e| {
+                    hax_lib::assume!(acc.to_int() + e.tls_serialized_len().to_int() <= usize::MAX.to_int());
+                    acc + e.tls_serialized_len()})
         }
     }
 }
@@ -47,6 +52,7 @@ macro_rules! impl_byte_size {
         /// The serialized len
         #[inline(always)]
         fn tls_serialized_byte_length(&$self) -> usize {
+            hax_lib::assume!($self.as_slice().len().to_int() + $len_len.to_int() <= usize::MAX.to_int());
             $self.as_slice().len() + $len_len
         }
     }
@@ -401,6 +407,7 @@ macro_rules! impl_vec_members {
         /// Add an element to this.
         #[inline]
         pub fn push(&mut self, value: $element_type) {
+            hax_lib::assume!(self.vec.len() < usize::MAX);
             self.vec.push(value);
         }
 

--- a/tls_codec/src/tls_vec.rs
+++ b/tls_codec/src/tls_vec.rs
@@ -19,11 +19,11 @@ macro_rules! impl_size {
     ($self:ident, $size:ty, $name:ident, $len_len:literal) => {
         /// The serialized len
         #[inline(always)]
-        fn tls_serialized_length(&$self) -> usize {
+        fn tls_serialized_length(&$self) -> Option<usize> {
             hax_lib::fstar!("admit ()"); // https://github.com/cryspen/hax/issues/1700
             $self.as_slice()
                 .iter()
-                .fold($len_len, |acc, e| acc + e.tls_serialized_len())
+                .fold(Some($len_len), |acc, e| acc?.checked_add(e.tls_serialized_len_checked()?))
         }
     }
 }
@@ -32,9 +32,8 @@ macro_rules! impl_byte_size {
     ($self:ident, $size:ty, $name:ident, $len_len:literal) => {
         /// The serialized len
         #[inline(always)]
-        fn tls_serialized_byte_length(&$self) -> usize {
-            hax_lib::fstar!("admit ()"); // overflow
-            $self.as_slice().len() + $len_len
+        fn tls_serialized_byte_length(&$self) -> Option<usize> {
+            $self.as_slice().len().checked_add($len_len)
         }
     }
 }
@@ -247,6 +246,10 @@ macro_rules! impl_tls_vec_codec_generic {
         impl<T: $($bounds + )* Size> Size for $name<T> {
             #[inline]
             fn tls_serialized_len(&self) -> usize {
+                self.tls_serialized_length().unwrap_or(0)
+            }
+            #[inline]
+            fn tls_serialized_len_checked(&self) -> Option<usize> {
                 self.tls_serialized_length()
             }
         }
@@ -261,6 +264,10 @@ macro_rules! impl_tls_vec_codec_generic {
         impl<T: $($bounds + )* Size> Size for &$name<T> {
             #[inline]
             fn tls_serialized_len(&self) -> usize {
+                self.tls_serialized_length().unwrap_or(0)
+            }
+            #[inline]
+            fn tls_serialized_len_checked(&self) -> Option<usize> {
                 self.tls_serialized_length()
             }
         }
@@ -291,8 +298,11 @@ macro_rules! impl_tls_vec_codec_bytes {
 
         impl Size for $name {
             #[inline]
-            fn tls_serialized_len(&self) -> usize {
+            fn tls_serialized_len_checked(&self) -> Option<usize> {
                 self.tls_serialized_byte_length()
+            }
+            fn tls_serialized_len(&self) -> usize {
+                self.tls_serialized_byte_length().unwrap_or(0)
             }
         }
 
@@ -305,8 +315,12 @@ macro_rules! impl_tls_vec_codec_bytes {
 
         impl Size for &$name {
             #[inline]
-            fn tls_serialized_len(&self) -> usize {
+            fn tls_serialized_len_checked(&self) -> Option<usize> {
                 self.tls_serialized_byte_length()
+            }
+            #[inline]
+            fn tls_serialized_len(&self) -> usize {
+                self.tls_serialized_byte_length().unwrap_or(0)
             }
         }
 
@@ -956,15 +970,23 @@ macro_rules! impl_tls_byte_slice {
 
         impl<'a> Size for &$name<'a> {
             #[inline]
-            fn tls_serialized_len(&self) -> usize {
+            fn tls_serialized_len_checked(&self) -> Option<usize> {
                 self.tls_serialized_byte_length()
+            }
+            #[inline]
+            fn tls_serialized_len(&self) -> usize {
+                self.tls_serialized_byte_length().unwrap_or(0)
             }
         }
 
         impl<'a> Size for $name<'a> {
             #[inline]
-            fn tls_serialized_len(&self) -> usize {
+            fn tls_serialized_len_checked(&self) -> Option<usize> {
                 self.tls_serialized_byte_length()
+            }
+            #[inline]
+            fn tls_serialized_len(&self) -> usize {
+                self.tls_serialized_byte_length().unwrap_or(0)
             }
         }
     };
@@ -1012,15 +1034,23 @@ macro_rules! impl_tls_slice {
 
         impl<'a, T: Size> Size for &$name<'a, T> {
             #[inline]
-            fn tls_serialized_len(&self) -> usize {
+            fn tls_serialized_len_checked(&self) -> Option<usize> {
                 self.tls_serialized_length()
+            }
+            #[inline]
+            fn tls_serialized_len(&self) -> usize {
+                self.tls_serialized_length().unwrap_or(0)
             }
         }
 
         impl<'a, T: Size> Size for $name<'a, T> {
             #[inline]
-            fn tls_serialized_len(&self) -> usize {
+            fn tls_serialized_len_checked(&self) -> Option<usize> {
                 self.tls_serialized_length()
+            }
+            #[inline]
+            fn tls_serialized_len(&self) -> usize {
+                self.tls_serialized_length().unwrap_or(0)
             }
         }
     };


### PR DESCRIPTION
This is a first step for proving panic freedom. Extraction using hax and F* type checking works, but some parts are admitted (with comments). The most common reasons for admits are:
- A proof is needed for the absence arithmetic overflow or underflow
- Conversion from `usize` to `U24` is unsafe (should work because it is used only on valid values but that makes it hard to prove)
- `debug_assert`s are not proven for now
- https://github.com/cryspen/hax/issues/1702
- https://github.com/cryspen/hax/issues/1700
- https://github.com/cryspen/hax/issues/1584
- https://github.com/cryspen/hax/issues/1704

The current state works with hax branch `tls-codec-panic-freedom`